### PR TITLE
fix naive functionality for sway

### DIFF
--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -173,16 +173,14 @@ func subscribeAndRender(monitor, file string) error {
 
 // detectCommand returns "swaymsg" if it successfully detects sway, otherwise "i3-msg".
 func detectCommand() string {
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
-	defer cancel()
+    ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+    defer cancel()
 
-	cmd := exec.CommandContext(ctx, "swaymsg", "-t", "get_version")
-	output, err := cmd.CombinedOutput()
-	if err == nil {
-		fmt.Printf("Detected swaymsg: %s", strings.TrimSpace(string(output)))
-		return "swaymsg"
-	}
-	return "i3-msg"
+    cmd := exec.CommandContext(ctx, "swaymsg", "-t", "get_version")
+    if err := cmd.Run(); err == nil {
+        return "swaymsg"
+    }
+    return "i3-msg"
 }
 
 // Run sets up and starts the subscription-render loop.

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -171,9 +171,15 @@ func subscribeAndRender(monitor, file string) error {
 	return nil
 }
 
-// detectCommand returns "swaymsg" if SWAYSOCK is set, otherwise "i3-msg".
+// detectCommand returns "swaymsg" if it successfully detects sway, otherwise "i3-msg".
 func detectCommand() string {
-	if os.Getenv("SWAYSOCK") != "" {
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "swaymsg", "-t", "get_version")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		fmt.Printf("Detected swaymsg: %s", strings.TrimSpace(string(output)))
 		return "swaymsg"
 	}
 	return "i3-msg"


### PR DESCRIPTION
### What
- Stop relying on env variables which can be fragile and just probe for swaymsg or i3-msg instead: 237bcee
- Stop printing out swaymsg version all the time: a3714f6
